### PR TITLE
Add MCP management facade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,6 +392,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -439,6 +473,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -1029,6 +1069,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1225,7 +1271,7 @@ dependencies = [
  "bytes",
  "futures",
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
@@ -1264,11 +1310,13 @@ dependencies = [
  "ngrok",
  "regex",
  "reqwest",
+ "rmcp",
  "serde",
  "serde_json",
  "sha2",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "toml",
  "tracing",
  "tracing-subscriber",
@@ -1444,6 +1492,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pastey"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1572,8 +1626,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1583,7 +1647,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1596,12 +1670,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.11.0",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1685,6 +1788,51 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rmcp"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bef41ebc9ebed2c1b1d90203e9d1756091e8a00bbc3107676151f39868ca0ee"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "futures",
+ "http",
+ "http-body",
+ "http-body-util",
+ "pastey",
+ "pin-project-lite",
+ "rand 0.9.2",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "sse-stream",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower-service",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e88ad84b8b6237a934534a62b379a5be6388915663c0cc598ceb9b3292bbbfe"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1792,6 +1940,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1863,6 +2037,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2023,6 +2208,19 @@ checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "sse-stream"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb4dc4d33c68ec1f27d386b5610a351922656e1fdf5c05bbaad930cd1519479a"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -2254,7 +2452,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
 dependencies = [
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "tokio",
 ]
 
@@ -2277,6 +2475,17 @@ dependencies = [
  "either",
  "futures-util",
  "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,9 @@ dotenvy = "0.15"
 ngrok = "0.18"
 futures = "0.3"
 jsonwebtoken = "9"
+tokio-util = "0.7"
+rmcp = { version = "0.15", features = [
+    "server",
+    "transport-streamable-http-server",
+    "transport-streamable-http-server-session",
+] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -81,6 +81,8 @@ pub struct RuleConfig {
     pub name: String,
     pub filter: FilterConfig,
     pub action: String,
+    #[serde(default = "default_true")]
+    pub enabled: bool,
     #[serde(default)]
     pub prompt: Option<String>,
     #[serde(default)]

--- a/src/github_auth.rs
+++ b/src/github_auth.rs
@@ -85,6 +85,11 @@ impl GitHubAppAuth {
         Ok(token)
     }
 
+    /// Force-refresh the cached installation token, bypassing the cache TTL.
+    pub async fn force_refresh(&self) -> Result<String, AuthError> {
+        self.refresh_token().await
+    }
+
     fn generate_jwt(&self) -> Result<String, AuthError> {
         let now = chrono::Utc::now().timestamp();
         let claims = JwtClaims {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod agent;
 mod cloud_event;
 mod github_auth;
 mod config;
+mod mcp;
 mod routing;
 mod server;
 mod verification;
@@ -46,7 +47,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "starting nexus-server"
     );
 
-    let router = server::build_router(config);
+    let router = server::build_router(config, cli.config.into());
     let listener = tokio::net::TcpListener::bind(&bind).await?;
     let local_addr = listener.local_addr()?;
     info!("listening on {local_addr}");

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -1,0 +1,35 @@
+mod server;
+mod tools;
+
+use std::sync::Arc;
+
+use axum::Router;
+use rmcp::transport::streamable_http_server::{
+    session::local::LocalSessionManager, tower::StreamableHttpService,
+    StreamableHttpServerConfig,
+};
+use tokio_util::sync::CancellationToken;
+use tracing::info;
+
+use crate::server::SharedState;
+
+/// Mount the MCP management endpoint onto the router.
+pub fn mount(router: Router, shared: Arc<SharedState>) -> Router {
+    let cancel = CancellationToken::new();
+    let config = StreamableHttpServerConfig {
+        stateful_mode: true,
+        cancellation_token: cancel.clone(),
+        ..Default::default()
+    };
+
+    let shared_for_factory = shared;
+    let service = StreamableHttpService::new(
+        move || Ok(server::NexusMcpServer::new(shared_for_factory.clone())),
+        Arc::new(LocalSessionManager::default()),
+        config,
+    );
+
+    info!("mounting MCP management endpoint at /mcp");
+
+    router.nest_service("/mcp", service)
+}

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1,0 +1,99 @@
+use std::sync::Arc;
+
+use rmcp::model::*;
+use rmcp::service::RequestContext;
+use rmcp::{ErrorData as McpError, RoleServer, ServerHandler};
+use serde_json::Value;
+
+use crate::server::SharedState;
+
+use super::tools;
+
+/// MCP server facade over the running nexus-server.
+pub struct NexusMcpServer {
+    shared: Arc<SharedState>,
+}
+
+impl NexusMcpServer {
+    pub fn new(shared: Arc<SharedState>) -> Self {
+        Self { shared }
+    }
+}
+
+impl ServerHandler for NexusMcpServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo {
+            protocol_version: ProtocolVersion::V_2025_03_26,
+            capabilities: ServerCapabilities::builder()
+                .enable_tools()
+                .build(),
+            server_info: Implementation {
+                name: "nexus-server".into(),
+                version: env!("CARGO_PKG_VERSION").into(),
+                title: None,
+                description: None,
+                icons: None,
+                website_url: None,
+            },
+            instructions: Some(
+                "Nexus webhook automation server — manage rules, view stats, and control the running instance."
+                    .to_string(),
+            ),
+        }
+    }
+
+    async fn list_tools(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListToolsResult, McpError> {
+        let defs = tools::definitions();
+        let tools: Vec<Tool> = defs
+            .into_iter()
+            .filter_map(|v| {
+                let name = v["name"].as_str()?.to_owned();
+                let description = v["description"].as_str().map(|s| s.to_owned());
+                let input_schema = v.get("inputSchema").cloned().unwrap_or(
+                    serde_json::json!({"type": "object", "properties": {}}),
+                );
+                Some(Tool {
+                    name: name.into(),
+                    description: description.map(Into::into),
+                    input_schema: serde_json::from_value(input_schema).ok()?,
+                    annotations: None,
+                    title: None,
+                    output_schema: None,
+                    execution: None,
+                    icons: None,
+                    meta: None,
+                })
+            })
+            .collect();
+
+        Ok(ListToolsResult {
+            tools,
+            next_cursor: None,
+            meta: None,
+        })
+    }
+
+    async fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, McpError> {
+        let args: Value = request
+            .arguments
+            .map(|m| serde_json::to_value(m).unwrap_or_default())
+            .unwrap_or(Value::Object(Default::default()));
+
+        let result = tools::execute(&request.name, &args, &self.shared).await;
+
+        Ok(CallToolResult {
+            content: vec![Content::text(result)],
+            is_error: None,
+            meta: None,
+            structured_content: None,
+        })
+    }
+}

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1,0 +1,177 @@
+use std::sync::atomic::Ordering;
+
+use serde_json::{json, Value};
+
+use crate::config::Config;
+use crate::server::SharedState;
+
+/// MCP tool definitions.
+pub fn definitions() -> Vec<Value> {
+    vec![
+        json!({
+            "name": "list_rules",
+            "description": "List all routing rules with their enabled state.",
+            "inputSchema": { "type": "object", "properties": {} }
+        }),
+        json!({
+            "name": "list_webhooks",
+            "description": "List all registered webhook endpoints.",
+            "inputSchema": { "type": "object", "properties": {} }
+        }),
+        json!({
+            "name": "server_stats",
+            "description": "Get server uptime and event processing statistics.",
+            "inputSchema": { "type": "object", "properties": {} }
+        }),
+        json!({
+            "name": "recent_events",
+            "description": "Get the most recently processed webhook events.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "limit": {
+                        "type": "integer",
+                        "description": "Max events to return (default: 20)"
+                    }
+                }
+            }
+        }),
+        json!({
+            "name": "enable_rule",
+            "description": "Enable a routing rule by name.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string", "description": "Rule name" }
+                },
+                "required": ["name"]
+            }
+        }),
+        json!({
+            "name": "disable_rule",
+            "description": "Disable a routing rule by name. Disabled rules are skipped during event matching.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string", "description": "Rule name" }
+                },
+                "required": ["name"]
+            }
+        }),
+        json!({
+            "name": "reload_config",
+            "description": "Reload rules from config.toml on disk. Replaces all rules with the new config.",
+            "inputSchema": { "type": "object", "properties": {} }
+        }),
+        json!({
+            "name": "refresh_github_token",
+            "description": "Force-refresh the cached GitHub App installation token.",
+            "inputSchema": { "type": "object", "properties": {} }
+        }),
+    ]
+}
+
+/// Dispatch a tool call and return the result as a string.
+pub async fn execute(name: &str, args: &Value, state: &SharedState) -> String {
+    match name {
+        "list_rules" => list_rules(state).await,
+        "list_webhooks" => list_webhooks(state),
+        "server_stats" => server_stats(state),
+        "recent_events" => recent_events(args, state).await,
+        "enable_rule" => set_rule_enabled(args, state, true).await,
+        "disable_rule" => set_rule_enabled(args, state, false).await,
+        "reload_config" => reload_config(state).await,
+        "refresh_github_token" => refresh_github_token(state).await,
+        _ => format!("Unknown tool: {name}"),
+    }
+}
+
+async fn list_rules(state: &SharedState) -> String {
+    let rules = state.rules.read().await;
+    let list: Vec<Value> = rules
+        .iter()
+        .map(|r| {
+            json!({
+                "name": r.name,
+                "filter": r.filter.type_prefix,
+                "action": r.action,
+                "enabled": r.enabled,
+            })
+        })
+        .collect();
+    serde_json::to_string_pretty(&list).unwrap_or_default()
+}
+
+fn list_webhooks(state: &SharedState) -> String {
+    // Webhook configs aren't stored on SharedState (consumed during router build).
+    // Return the count — full webhook info would require storing them.
+    json!({
+        "webhook_count": state.webhook_count,
+        "note": "Webhook details are consumed during router initialization. Use /status for counts."
+    })
+    .to_string()
+}
+
+fn server_stats(state: &SharedState) -> String {
+    let stats = &state.stats;
+    let uptime = chrono::Utc::now() - stats.started_at;
+
+    json!({
+        "started_at": stats.started_at.to_rfc3339(),
+        "uptime_seconds": uptime.num_seconds(),
+        "events_received": stats.events_received.load(Ordering::Relaxed),
+        "events_matched": stats.events_matched.load(Ordering::Relaxed),
+        "actions_succeeded": stats.actions_succeeded.load(Ordering::Relaxed),
+        "actions_failed": stats.actions_failed.load(Ordering::Relaxed),
+        "webhooks": state.webhook_count,
+    })
+    .to_string()
+}
+
+async fn recent_events(args: &Value, state: &SharedState) -> String {
+    let limit = args["limit"].as_u64().unwrap_or(20) as usize;
+    let events = state.recent_events.lock().await;
+    let recent: Vec<&crate::server::RecentEvent> = events.iter().rev().take(limit).collect();
+    serde_json::to_string_pretty(&recent).unwrap_or_default()
+}
+
+async fn set_rule_enabled(args: &Value, state: &SharedState, enabled: bool) -> String {
+    let name = match args["name"].as_str() {
+        Some(n) => n,
+        None => return "Error: missing 'name' argument".to_string(),
+    };
+
+    let mut rules = state.rules.write().await;
+    if let Some(rule) = rules.iter_mut().find(|r| r.name == name) {
+        rule.enabled = enabled;
+        let action = if enabled { "enabled" } else { "disabled" };
+        format!("Rule '{}' {action}", rule.name)
+    } else {
+        let available: Vec<&str> = rules.iter().map(|r| r.name.as_str()).collect();
+        format!("Rule '{name}' not found. Available: {available:?}")
+    }
+}
+
+async fn reload_config(state: &SharedState) -> String {
+    let path = state.config_path.to_string_lossy().to_string();
+    // Convert the non-Send Box<dyn Error> to String before any .await
+    match Config::load(&path).map_err(|e| e.to_string()) {
+        Ok(new_config) => {
+            let count = new_config.rules.len();
+            let mut rules = state.rules.write().await;
+            *rules = new_config.rules;
+            format!("Config reloaded from {path}: {count} rules")
+        }
+        Err(e) => format!("Error reloading config: {e}"),
+    }
+}
+
+async fn refresh_github_token(state: &SharedState) -> String {
+    match &state.github_app {
+        Some(app) => match app.force_refresh().await {
+            Ok(_) => "GitHub App token refreshed".to_string(),
+            Err(e) => format!("Error refreshing token: {e}"),
+        },
+        None => "No GitHub App auth configured — using static PAT from env".to_string(),
+    }
+}

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -9,7 +9,7 @@ pub fn match_rules<'a>(
 ) -> Vec<&'a RuleConfig> {
     rules
         .iter()
-        .filter(|r| event.type_.starts_with(&r.filter.type_prefix))
+        .filter(|r| r.enabled && event.type_.starts_with(&r.filter.type_prefix))
         .collect()
 }
 
@@ -57,6 +57,7 @@ mod tests {
                 type_prefix: prefix.to_string(),
             },
             action: action.to_string(),
+            enabled: true,
             prompt: None,
             system_prompt: None,
             url: None,


### PR DESCRIPTION
## Summary
- Adds a Streamable HTTP MCP endpoint at `POST /mcp` using `rmcp` (same pattern as the Nexus app)
- 8 management tools exposed as a thin facade over `SharedState`: rule listing/toggling, config reload, stats, recent events, GitHub token refresh
- Core changes: rules in `RwLock` for runtime mutation, atomic `ServerStats` counters, bounded `RecentEvent` buffer, `enabled` field on rules

## Connection
```json
{
  "mcpServers": {
    "nexus-server": {
      "type": "url",
      "url": "http://<server-ip>:8090/mcp"
    }
  }
}
```

## Test plan
- [x] `cargo build` — clean
- [x] `cargo test` — 13/13 pass
- [x] `cargo clippy -- -D warnings` — clean
- [ ] Start server, connect Claude Code to `/mcp`, verify tool discovery
- [ ] `disable_rule` → trigger webhook → verify rule skipped
- [ ] `reload_config` after editing config.toml → verify new rules appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)