### PR TITLE
fix: stateless MCP + version bump to 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1416,7 +1416,7 @@ dependencies = [
 
 [[package]]
 name = "nexus-server"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "axum",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexus-server"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## Summary
- Switch MCP endpoint to stateless mode (`stateful_mode: false`) so Claude Code can reconnect after server restarts without stale session errors
- Bump version to 0.2.1

## Test plan
- [ ] Verify MCP tools work after server restart without OAuth/404 errors
- [ ] Confirm workflow trigger routing still functions with the v0.2.0 changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)